### PR TITLE
feat!: remove dependency on nvim-treesitter

### DIFF
--- a/lua/cellular-automaton/init.lua
+++ b/lua/cellular-automaton/init.lua
@@ -44,8 +44,10 @@ M.start_animation = function(animation_name)
   end
 
   -- Make sure nvim treesitter parser exists for current buffer
-  if not require("nvim-treesitter.parsers").has_parser() then
-    error("Error while starting an animation. Current buffer doesn't have associated nvim-treesitter parser.")
+  local ft = vim.bo[0].filetype
+  local lang = vim.treesitter.language.get_lang(ft)
+  if not lang then
+    error("Error while starting an animation. Current buffer doesn't have associated tree-sitter parser.")
   end
 
   manager.execute_animation(M.animations[animation_name])

--- a/plugin/cellular-automaton.lua
+++ b/plugin/cellular-automaton.lua
@@ -1,11 +1,5 @@
-if 1 ~= vim.fn.has("nvim-0.8.0") then
-  vim.api.nvim_err_writeln("Cellular-automaton.nvim requires at least nvim-0.8.0")
-  return
-end
-
-local ok, _ = pcall(require, "nvim-treesitter")
-if not ok then
-  vim.api.nvim_err_writeln("Cellular-automaton.nvim requires nvim-treesitter/nvim-treesitter plugin to be installed.")
+if 1 ~= vim.fn.has("nvim-0.9.0") then
+  vim.api.nvim_err_writeln("Cellular-automaton.nvim requires at least nvim-0.9.0")
   return
 end
 


### PR DESCRIPTION
nvim-treesitter is removing its API and has upstreamed most of it to core.

See also: https://github.com/nvim-treesitter/nvim-treesitter/issues/4767

This PR removes the dependency on nvim-treesitter, and instead uses Neovim's core API.

It seems like it only actually used nvim-treesitter to check for the presence of parsers (?).

This bumps the minimum required Neovim version to 0.9.
