### PR TITLE
Better UTF-8 and tabs support

### DIFF
--- a/lua/cellular-automaton/load.lua
+++ b/lua/cellular-automaton/load.lua
@@ -59,6 +59,13 @@ local get_usable_window_width = function()
 end
 
 M.load_base_grid = function(window, buffer)
+  if vim.bo[buffer].fileencoding ~= "utf-8" then
+    -- NOTE(libro): Is it necessary? Previously this plugin didn't handle
+    --   multibyte-chars properly - so if buffer is not UTF8-encoded then
+    --   the animation will be rusty as it was for UTF-8 buffers earlier
+    error("Only UTF-8 buffers are supported")
+  end
+
   local window_width = get_usable_window_width()
   local vertical_range = {
     start = vim.fn.line("w0") - 1,

--- a/lua/cellular-automaton/ui.lua
+++ b/lua/cellular-automaton/ui.lua
@@ -48,7 +48,7 @@ M.render_frame = function(grid)
     local width = #row
     local cells_displayed = 0
     for _, cell in ipairs(row) do
-      cells_displayed = cells_displayed + vim.fn.strdisplaywidth(cell.char)
+      cells_displayed = cells_displayed + vim.fn.strdisplaywidth(cell.char, cells_displayed)
       if cells_displayed > width then
         break
       end

--- a/lua/cellular-automaton/ui.lua
+++ b/lua/cellular-automaton/ui.lua
@@ -29,8 +29,17 @@ M.open_window = function(host_window)
     row = 0,
     col = 0,
   })
-  vim.api.nvim_win_set_option(window_id, "winhl", "Normal:CellularAutomatonNormal")
-  vim.api.nvim_win_set_option(window_id, "list", false)
+
+  vim.wo[window_id].winhl = "Normal:CellularAutomatonNormal"
+  vim.wo[window_id].list = true
+
+  for _, bufnr in ipairs(buffers) do
+    -- NOTE(libro): According to *:help vim.wo* only bufnr=0
+    --   is supported for local window options
+    vim.api.nvim_win_set_buf(window_id, bufnr)
+    vim.wo[window_id][0].listchars = "tab:<->"
+  end
+
   return window_id, buffers
 end
 


### PR DESCRIPTION
Closes #30.

Better UTF-8 support because now we're iterating over UTF-8 symbols (which can be up to 4 bytes long) when initializing grid. Also there's **strdisplaywidth()** calls under the hood to properly calculate how many cells will be occupied by each of grid cells to prevent nvim lines to wrap.

**strdisplaywidth()** also respects **tabstop** which is nice - i checked it with make_it_rain animation and it looks fine IMO, but *slide* animation (the one from README example) looks a bit silly when buffer contains tabulations :) The other options is to pre-calculate every tab width on initial lines respecting **tabstop** and replace it with corresponding amount of spaces to make animations "less dynamic" and more predictable.

I also made a check if buffer **fileencoding** is UTF-8 but maybe it is not that necessary. Previously this plugin didn't handle multibyte-chars good enough - so if buffer is not UTF8-encoded then the animation will be probably *not good* as it is for UTF-8 buffers before the changes I'm proposing.

Another thing I made was 'list' option enabling (only tab option was set in 'listchars') - it was easier for me to debug how tabs are behaving on each animation frame - also it's easy to revert.

This PR is raw, no tests was written (never used **luassert/busted** before), probably i will have a free time this weekend to write some