### PR TITLE
fix: correctly work when filetype does not match parser name

### DIFF
--- a/lua/cellular-automaton/init.lua
+++ b/lua/cellular-automaton/init.lua
@@ -46,7 +46,7 @@ M.start_animation = function(animation_name)
   -- Make sure nvim treesitter parser exists for current buffer
   local filetype = vim.bo.filetype
   local function raise_if_parser_missing()
-    vim.treesitter.language.inspect(filetype)
+    vim.treesitter.language.inspect(vim.treesitter.language.get_lang(filetype) or filetype)
   end
   local success, err = pcall(raise_if_parser_missing)
   if not success then


### PR DESCRIPTION
fixes #34

`vim.treesitter.language.get_lang()` returns `nil` for unknown filetypes, therefore `or filetype` will ensure error message is the same as before.